### PR TITLE
Remove unused `with_abort()`

### DIFF
--- a/R/ast.R
+++ b/R/ast.R
@@ -17,7 +17,7 @@ transform_ast <- function(node, transformer, ...){
     return(node)
   }else if(rlang::is_pairlist(node)){
     lapply(node, transform_ast, ...) %>%
-      rlang::as_pairlist() %>%
+      as.pairlist() %>%
       return()
   }else if(is.null(node)){
     return(node)

--- a/R/declaration-creation.R
+++ b/R/declaration-creation.R
@@ -90,7 +90,7 @@ as_declaration.name <- function(x) new_declaration(list(NULL), list(x))
 # user-facing version with informative error message
 ui_as_declaration <- function(x) {
   rlang::with_handlers(
-    rlang::with_abort(as_declaration(x)),
+    as_declaration(x),
     error = ~ rlang::abort(
       c(
         "Invalid declaration",

--- a/R/declaration-creation.R
+++ b/R/declaration-creation.R
@@ -88,15 +88,18 @@ as_declaration.character <- function(x) {
 as_declaration.name <- function(x) new_declaration(list(NULL), list(x))
 
 # user-facing version with informative error message
-ui_as_declaration <- function(x) {
-  rlang::with_handlers(
+ui_as_declaration <- function(x, error_call) {
+  withCallingHandlers(
     as_declaration(x),
-    error = ~ rlang::abort(
+    error = function(cnd) rlang::abort(
       c(
         "Invalid declaration",
         x = paste0("'", rlang::as_label(rlang::enexpr(x)), "' can not be interpreted as a declaration."),
         i = "A declaration can be specified as a formula, number or the name of a variable."
-      )
+      ),
+      call = error_call,
+      parent = cnd,
+      use_cli_format = TRUE
     )
   )
 }

--- a/R/observation.R
+++ b/R/observation.R
@@ -162,8 +162,12 @@ obs_combined <- function(prediction, name, var_prop = 0.1, var_add = 1) {
   )
 }
 
-validate_and_create_observation <- function(constructor, prediction, name, values) {
-  prediction <- ui_as_declaration(prediction)
+validate_and_create_observation <- function(constructor,
+                                            prediction,
+                                            name,
+                                            values,
+                                            error_call = parent.frame()) {
+  prediction <- ui_as_declaration(prediction, error_call = error_call)
   if (rlang::is_missing(name)) name <- dcl_make_obs_names(prediction)
   assert_valid_observation_name(name)
   constructor(prediction = prediction, name = name, values = values)


### PR DESCRIPTION
The first commit removes the call to `with_abort()` as it ends up being redundant since you immediately throw a different error when an error occurs. You are the only package using `with_abort()` and I might deprecate or even remove this function in the next rlang version.

The second commit rethrows the error as a chained error and supplies contextual data. This metadata is not used in the current CRAN rlang version, but will be used in the next version to enrich error messages displayed to users.

With these changes and CRAN rlang:

```r
create_prediction <- function() {
  stop("Failing.")
}

model() + obs_additive(create_prediction())
#> Error: Invalid declaration
#> ✖ 'prediction' can not be interpreted as a declaration.
#> ℹ A declaration can be specified as a formula, number or the name of a variable.
```

With dev rlang:

```r
model() + obs_additive(create_prediction())
#> Error in `obs_additive()`:
#>   Invalid declaration
#>   ✖ 'prediction' can not be interpreted as a declaration.
#>   ℹ A declaration can be specified as a formula, number or the name of a
#>     variable.
#> Caused by error in `create_prediction()`:
#>   Failing.
```

We'll communicate about chained errors on the tidyverse blog. We'll also add more documentation to rlang (you can track this at https://github.com/r-lib/rlang/issues/1267).

Feel free to disregard the second commit but it'd be great to send the first commit to CRAN within 3 or 4 weeks as we plan to release the next version of rlang soonish.